### PR TITLE
ctx/feat(cache): configurable tls settings

### DIFF
--- a/infra/cache/config.go
+++ b/infra/cache/config.go
@@ -11,11 +11,12 @@ import (
 
 // RedisConfig holds redis connection info
 type RedisConfig struct {
-	Host     string        `json:"host" yaml:"host" validate:"notempty"`
-	Port     int           `json:"port" yaml:"port" validate:"notzero"`
-	DBName   uint8         `json:"dbname" yaml:"dbname"`
-	Username string        `json:"username" yaml:"username"`
-	Password secret.String `json:"password" yaml:"password"`
+	Host      string        `json:"host" yaml:"host" validate:"notempty"`
+	Port      int           `json:"port" yaml:"port" validate:"notzero"`
+	DBName    uint8         `json:"dbname" yaml:"dbname"`
+	Username  string        `json:"username" yaml:"username"`
+	Password  secret.String `json:"password" yaml:"password"`
+	EnableTLS bool          `json:"enable_tls" yaml:"enable_tls"`
 }
 
 func (cfg *RedisConfig) extraValidate() error {
@@ -46,7 +47,7 @@ func (cfg RedisConfig) CacheKey() string {
 // RegionalRedisConfig holds redis connection info for a specific region
 type RegionalRedisConfig struct {
 	RedisConfig `yaml:",inline" json:",inline"` // embedding this to make it easy to manage
-	Region      region.MachineRegion            `json:"region" yaml:"region"`
+	Region      region.MachineRegion `json:"region" yaml:"region"`
 }
 
 //go:generate genvalidate RegionalRedisConfig

--- a/internal/skeleton/skeleton.go
+++ b/internal/skeleton/skeleton.go
@@ -159,18 +159,7 @@ func InitServer(ctx context.Context, args InitServerArgs) (Server, error) {
 			closersFuncs = append(closersFuncs, closeTracing)
 		}
 	}
-	uv := universe.Current()
-	if uv.IsCloud() {
-		if err := cache.InitRedisCertForCloud(); err != nil {
-			return Server{}, ucerr.Wrap(err)
-		}
-	} else if uv.IsOnPrem() {
-		// In on prem, redis runs locally in the cluster, but may not be available yet when the UC service starts,so we wait for it to be available.
-		// if it is not available, we will fail the service start (crashes the pod/container) which will cause k8s to retry.
-		if err := waitForRedis(ctx, args.CacheConfig); err != nil {
-			return Server{}, ucerr.Wrap(err)
-		}
-	}
+
 	srv := Server{
 		service:             args.Service,
 		serviceInstanceName: args.ServiceInstanceName,


### PR DESCRIPTION
Allows TLS settings to be managed in the cache configuration.  Previously the determination to use TLS was based on whether or not the service was running in the "cloud" universe.  This allows for local installs to also use caches with TLS transport enabled.